### PR TITLE
Update URL's to keep the script working

### DIFF
--- a/owlet_monitor
+++ b/owlet_monitor
@@ -3,8 +3,8 @@
 import sys, os, time, requests, json
 
 sess = None
-url_login = 'https://user-field.aylanetworks.com/users/sign_in'
-url_base = 'https://ads-field.aylanetworks.com/apiv1'
+url_login = 'https://user-field-1a2039d9.aylanetworks.com/users/sign_in'
+url_base = 'https://ads-field-1a2039d9.aylanetworks.com/apiv1'
 url_devs = url_base + '/devices'
 url_props = None
 url_activate = None


### PR DESCRIPTION
As of 2019-07-23, the script stopped working, due to server-side changes done by Owlet (their own app also stopped working for a brief period).

After lots of digging with Charles Proxy, the change turned out to be really simple to reflect on the script.