### PR TITLE
Multiple Owlet Devices Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each CSV line consists of:
 * heart rate (BPM)
 * blood oxygen level (%)
 * movement (from sock sensor: baby still or wiggling)
+* device serial number (useful for multiple babies/owlet devices)
 
 If you are using an Owlet in Europe, set the `OWLET_REGION` environment variable to `europe` to use the European servers otherwise you may get a `400`/`EMAIL_NOT_FOUND` error.
 

--- a/index.html
+++ b/index.html
@@ -27,8 +27,8 @@ g = new Dygraph(
 	document.getElementById("graphdiv"),
 	window.location.search.slice(1),
 	{
-	    labels: ["Time", "Heart", "Oxygen", "Movement"],
-	    visibility: [true, false, false],
+	    labels: ["Time", "Heart", "Oxygen", "Movement", "Device SN"],
+	    visibility: [true, false, false, false],
 	    legend: "always",
 	    labelsDiv: document.getElementById('status'),
 	    color: "red",

--- a/owlet_monitor
+++ b/owlet_monitor
@@ -107,29 +107,43 @@ def fetch_dsn():
         devs = r.json()
         if len(devs) < 1:
             raise FatalError('Found zero Owlet monitors')
-        dsn = devs[0]['device']['dsn']
-        log('Found Owlet monitor device serial number %s' % dsn)
-        url_props = region_config[owlet_region]['url_base'] + \
-            '/dsns/' + dsn + '/properties.json'
-        url_activate = region_config[owlet_region]['url_base'] + \
-            '/dsns/' + dsn + '/properties/APP_ACTIVE/datapoints.json'
+        # Allow for multiple devices
+        dsn = []
+        url_props = []
+        url_activate = [] 
+        for device in devs:
+            device_sn = device['device']['dsn']
+            dsn.append(device_sn)
+            log('Found Owlet monitor device serial number %s' % device_sn)
+            url_props.append(
+                region_config[owlet_region]['url_base'] + '/dsns/' + device_sn 
+                + '/properties.json'
+            )
+            url_activate.append(
+                region_config[owlet_region]['url_base'] + '/dsns/' + device_sn 
+                + '/properties/APP_ACTIVE/datapoints.json'
+            )
 
-def reactivate():
+def reactivate(url_activate):
     payload = { "datapoint": { "metadata": {}, "value": 1 } }
     r = sess.post(url_activate, json=payload, headers=headers)
     r.raise_for_status()
 
 def fetch_props():
     # Ayla cloud API data is updated only when APP_ACTIVE periodically reset to 1.
-    reactivate()
-    my_props = {}
-    r = sess.get(url_props, headers=headers)
-    r.raise_for_status()
-    props = r.json()
-    for prop in props:
-        n = prop['property']['name']
-        del(prop['property']['name'])
-        my_props[n] = prop['property']
+    my_props = []
+    # Get properties for each device; note no pause between requests for each device
+    for next_url_activate,next_url_props in zip(url_activate,url_props):
+        reactivate(next_url_activate)
+        device_props = {}
+        r = sess.get(next_url_props, headers=headers)
+        r.raise_for_status()
+        props = r.json()
+        for prop in props:
+            n = prop['property']['name']
+            del(prop['property']['name'])
+            device_props[n] = prop['property']
+        my_props.append(device_props)
     return my_props
 
 def record_vitals(p):
@@ -164,7 +178,8 @@ def loop():
         try:
             login()
             fetch_dsn()
-            record_vitals(fetch_props())
+            for prop in fetch_props():
+                record_vitals(prop)
             time.sleep(10)
         except requests.exceptions.RequestException as e:
             log('Network error: %s' % e)

--- a/owlet_monitor
+++ b/owlet_monitor
@@ -133,9 +133,9 @@ def fetch_props():
     # Ayla cloud API data is updated only when APP_ACTIVE periodically reset to 1.
     my_props = []
     # Get properties for each device; note no pause between requests for each device
-    for next_url_activate,next_url_props in zip(url_activate,url_props):
+    for device_sn,next_url_activate,next_url_props in zip(dsn,url_activate,url_props):
         reactivate(next_url_activate)
-        device_props = {}
+        device_props = {'DSN':device_sn}
         r = sess.get(next_url_props, headers=headers)
         r.raise_for_status()
         props = r.json()
@@ -147,6 +147,7 @@ def fetch_props():
     return my_props
 
 def record_vitals(p):
+    device_sn = p['DSN']
     charge_status = p['CHARGE_STATUS']['value']
     base_station_on = p['BASE_STATION_ON']['value']
     heart = "%d" % p['HEART_RATE']['value']
@@ -165,11 +166,11 @@ def record_vitals(p):
         elif base_station_on == 1:
             # base station was intentionally turned on, the sock is presumably
             # on the baby's foot, so we can trust heart and oxygen levels
-            disp += heart + ", " + oxy + ", " + mov
+            disp += heart + ", " + oxy + ", " + mov + ", " + device_sn
             record(disp)
         else:
             raise FatalError("Unexpected base_station_on=%d" % base_station_on)
-    log("Status: " + disp)
+    log("%s Status: " % device_sn + disp)
 
 def loop():
     global sess


### PR DESCRIPTION
Resolves #7 

Logs data from multiple Owlet devices (e.g. twins) retrieved by `fetch_dsn()`. Particularly useful for twins each with their own device but on the same Owlet account.

Possible issues:
- Pulling data for "many" devices could reach API limit since a request happens in `fetch_dsn()` for each device. Though, tested with two devices and had no issues.
- The dashboard now works with device SN in the CSV but will not display correctly for multiple devices (graph interprets values from different devices as one line).